### PR TITLE
Fix typo occurrences of scipt

### DIFF
--- a/Create-KeyTab.ps1
+++ b/Create-KeyTab.ps1
@@ -17,7 +17,7 @@
 
 <# 
 .DESCRIPTION 
- This scipt will generate off-line keytab files for use with Active Directory (AD). While the script is designed to work independently of AD, this script can be used with a wrapper script that uses Get-ADUser or Get-ADObject to retrieve the UPN of a samaccountname or a list of samaccountnames for use in batch processing of KeyTab creation. More information at https://therealadamburford.github.io/Create-KeyTab/ 
+ This script will generate off-line keytab files for use with Active Directory (AD). While the script is designed to work independently of AD, this script can be used with a wrapper script that uses Get-ADUser or Get-ADObject to retrieve the UPN of a samaccountname or a list of samaccountnames for use in batch processing of KeyTab creation. More information at https://therealadamburford.github.io/Create-KeyTab/ 
 #> 
 ##########################################################
 ###

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 <body>
 <a href="https://github.com/TheRealAdamBurford/Create-KeyTab">Create KeyTab Project</a> 
 <h2 id="Create-Keytab-ps1">Create A KeyTab File Using PowerShell</h2>
-<p>This scipt will generate off-line keytab files for use with Active Directory (AD). While the script is designed to work independently of AD, this script can be used with a wrapper script that uses Get-ADUser or Get-ADObject to retrieve the UPN of a samaccountname or a list of samaccountnames for use in batch processing  of KeyTab creation.</p>
+<p>This script will generate off-line keytab files for use with Active Directory (AD). While the script is designed to work independently of AD, this script can be used with a wrapper script that uses Get-ADUser or Get-ADObject to retrieve the UPN of a samaccountname or a list of samaccountnames for use in batch processing  of KeyTab creation.</p>
 
 <p>The script is an alternative to ktpass. It offers the benefit of running on any server or workstation with PowerShell. The script allows the delegation of KeyTab file creation to individuals who are not domain admins. As long as the account has a UPN and the user/group creating KeyTab files are able to read the UPN and have knowledge of the password they can successfully create a working KeyTab file.</p>
 


### PR DESCRIPTION
## Summary
- fix minor spelling error in Create-KeyTab.ps1 header comment
- correct the same typo in docs/index.md

## Testing
- `grep -rni scipt`

------
https://chatgpt.com/codex/tasks/task_e_6841f370dcb48320ab4d0afc2151c4da