### PR TITLE
Fix Encrypt-AES parameter usage

### DIFF
--- a/Create-KeyTab.ps1
+++ b/Create-KeyTab.ps1
@@ -311,6 +311,8 @@ param (
 [Parameter(Mandatory=$true)]$Data
 )
 
+### All arguments should be supplied as byte arrays
+
 ### AES 128-CTS
 # KeySize = 16
 # AESKey = Encrypt-AES -KeyData PBKdf2 -IVData IV -Data NFoldText
@@ -333,7 +335,7 @@ param (
     $Aes.Padding = [System.Security.Cryptography.PaddingMode]::None
     $Aes.BlockSize = 128
 
-    $encryptor = $Aes.CreateEncryptor($key,$IV)
+    $encryptor = $Aes.CreateEncryptor($KeyData,$IVData)
     $memStream = new-Object IO.MemoryStream
 
     [byte[]] $AESKey = @()


### PR DESCRIPTION
## Summary
- ensure Encrypt-AES uses $KeyData and $IVData
- clarify the expected argument types in Encrypt-AES

## Testing
- `pwsh -v` *(fails: command not found)*
- `powershell -Command "$PSVersionTable.PSVersion"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f3ff1bdc8320937dbeae634c4a36