### PR TITLE
Fix comment typos

### DIFF
--- a/Create-KeyTab.ps1
+++ b/Create-KeyTab.ps1
@@ -630,8 +630,8 @@ $SALT += $($PrincipalArray[$i].Replace('/',""))
 }
 
 }
-### Finish spliting principal into component parts. PrincipalArray should have at most 2 elements. Testing with Java based tools, 
-### the keytab entry can only support one UPN. The components portion of the keytab entry appears to only be for spliting
+### Finish splitting principal into component parts. PrincipalArray should have at most 2 elements. Testing with Java-based tools,
+### the keytab entry can only support one UPN. The components portion of the keytab entry appears to only be for splitting
 ### a UPN in an SPN format. e.g. HOST/user@dev.home
 $PrincipalText = $Principal
 $Principal = $Principal.Replace('/',",")


### PR DESCRIPTION
## Summary
- fix spelling of "splitting" in comments around line 633

## Testing
- `grep -n splitting -n Create-KeyTab.ps1`
- `grep -n spliting -i Create-KeyTab.ps1`

------
https://chatgpt.com/codex/tasks/task_e_6841f433a9108320801c0a598a393417