### PR TITLE
Rename module to KeyTabTools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Build artifacts
+bin/
+obj/
+*.nupkg
+*.zip
+
+# Logs and transient files
+*.log
+*.tmp
+*.cache
+
+# IDE settings
+.vscode/
+.idea/
+
+# Test results
+TestResults/
+

--- a/KeyTabTools.ps1
+++ b/KeyTabTools.ps1
@@ -1,5 +1,5 @@
 <#PSScriptInfo
-.VERSION 1.0.2
+.VERSION 1.1.0
 .GUID 325f7f9a-87be-42ec-ba96-c5e423718284
 .AUTHOR TRAB
 .COMPANYNAME
@@ -21,7 +21,7 @@
 #> 
 ##########################################################
 ###
-###      Create-KeyTab.ps1
+###      KeyTabTools.ps1
 ###
 ###      Created : 2019-10-26
 ###      Modified: 2020-10-26
@@ -81,15 +81,15 @@ Optional Parameters
 -NoPrompt  : Suppress Write KeyTab File Prompt
 
 .EXAMPLE
-.\Create-KeyTab.ps1
+.\KeyTabTools.ps1
 .EXAMPLE
-.\Create-KeyTab.ps1 -AES256 -AES128 -RC4
+.\KeyTabTools.ps1 -AES256 -AES128 -RC4
 .EXAMPLE
-.\Create-KeyTab.ps1 -AES256 -AES128 -Append
+.\KeyTabTools.ps1 -AES256 -AES128 -Append
 .EXAMPLE
-.\Create-KeyTab.ps1 -AES256 -AES128 -SALT "MY.REALM.COMprincipalname"
+.\KeyTabTools.ps1 -AES256 -AES128 -SALT "MY.REALM.COMprincipalname"
 .EXAMPLE
-.\Create-KeyTab.ps1 -Realm "MY.REALM.COM" -Principal "principalname" -Password "Secret" -File "c:\temp\login.keytab"
+.\KeyTabTools.ps1 -Realm "MY.REALM.COM" -Principal "principalname" -Password "Secret" -File "c:\temp\login.keytab"
 
 .NOTES
 Use -QUIET and -NOPROMPT for batch mode processing.
@@ -97,6 +97,7 @@ Use -QUIET and -NOPROMPT for batch mode processing.
 .LINK
 https://www.linkedin.com/in/adamburford
 #>
+if ($MyInvocation.InvocationName -ne ".") {
 param (
 [Parameter(Mandatory=$true,HelpMessage="REALM name will be forced to Upper Case")]$Realm,
 [Parameter(Mandatory=$true,HelpMessage="Principal is case sensative. It must match the principal portion of the UPN",ValueFromPipelineByPropertyName=$true)]$Principal,
@@ -112,6 +113,7 @@ param (
 [Parameter(Mandatory=$false)][Switch]$Quiet,
 [Parameter(Mandatory=$false)][Switch]$NoPrompt
 )
+}
 
 function Get-MD4{
     PARAM(
@@ -606,6 +608,7 @@ return $password
 }
 
 
+if ($MyInvocation.InvocationName -ne ".") {
 if ([string]::IsNullOrEmpty($Password)){$Password = $(Get-Password)}
 
 if ([string]::IsNullOrEmpty($File)){$File=$(Get-Location).Path+'\login.keytab'}
@@ -709,3 +712,5 @@ $fileBytes += $keyTabVersion
 $fileBytes += $keyTabEntries
 [System.IO.File]::WriteAllBytes($File,$fileBytes)
 }
+}
+Export-ModuleMember -Function Get-MD4,Get-PBKDF2,Encrypt-AES,Get-AES128Key,Get-AES256Key,Get-HexStringFromByteArray,Get-ByteArrayFromHexString,Get-BytesBigEndian,Get-PrincipalType,Create-KeyTabEntry

--- a/KeyTabTools.psd1
+++ b/KeyTabTools.psd1
@@ -1,0 +1,11 @@
+@{
+    RootModule = 'KeyTabTools.ps1'
+    ModuleVersion = '1.1.0'
+    GUID = '325f7f9a-87be-42ec-ba96-c5e423718284'
+    Author = 'TRAB'
+    CompanyName = ''
+    Copyright = ''
+    Description = 'Utility functions for creating offline keytab files.'
+    FunctionsToExport = @('Get-MD4','Get-PBKDF2','Encrypt-AES','Get-AES128Key','Get-AES256Key','Get-HexStringFromByteArray','Get-ByteArrayFromHexString','Get-BytesBigEndian','Get-PrincipalType','Create-KeyTabEntry')
+    PowerShellVersion = '5.1'
+}

--- a/README.md
+++ b/README.md
@@ -1,17 +1,33 @@
-<html>
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<!--
-  The above 2 meta tags *must* come first in the <head>
-  to consistently ensure proper document rendering.
-  Any other head element should come *after* these tags.
- -->
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-</head>
-<body>
-  <p><b>Create A KeyTab File Using PowerShell Script</b></p>
-  <p>Follow this link for documentation.</p>
-<a href="https://therealadamburford.github.io/Create-KeyTab/">https://therealadamburford.github.io/Create-KeyTab/</a> 
-</body>
-</html>
+# KeyTabTools
+
+KeyTabTools is a PowerShell utility for generating offline keytab files for Active Directory accounts. It can be used on any system with PowerShell and does not require direct domain access.
+
+## Requirements
+
+- PowerShell 5.1 or later
+- Knowledge of the account password and UPN or service principal name
+
+## Installation
+
+Clone this repository and import the module:
+
+```powershell
+Import-Module ./KeyTabTools.psd1
+```
+
+Alternatively, you can run the script directly:
+
+```powershell
+./KeyTabTools.ps1 -Realm DEV.HOME -Principal http/AppService -AES256
+```
+
+## Usage
+
+When imported as a module, the helper functions become available. To generate a keytab via the script, run it with the desired parameters. Default encryption is AES256.
+
+```powershell
+./KeyTabTools.ps1 -Realm DEV.HOME -Principal user@dev.home -File .\login.keytab
+```
+
+See the [documentation site](https://therealadamburford.github.io/Create-KeyTab/) for detailed examples and parameter explanations.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,11 +28,11 @@
 <h3 id="Examples">Examples</h3>
 
 <h4 id="Example01">Create a KeyTab file with parameters.</h4>
-<p><i>PS D:\Temp> .\Create-KeyTab.ps1 -AES128 -AES256 -Realm DEV.HOME -Principal http/AppService</i></p>
+<p><i>PS D:\Temp> .\KeyTabTools.ps1 -AES128 -AES256 -Realm DEV.HOME -Principal http/AppService</i></p>
 <img src="images/CreateKeytab01.png" id="Image1" alt="">
 
 <h4 id="Example02">Create a KeyTab without parameters.</h4>
-<p><i>PS D:\Temp> .\Create-KeyTab.ps1</i></p>
+<p><i>PS D:\Temp> .\KeyTabTools.ps1</i></p>
 Deafult encryption is AES-256.
 <img src="images/CreateKeytab02.png" id="Image1" alt="">
 


### PR DESCRIPTION
## Summary
- rename module script and manifest to **KeyTabTools**
- bump version numbers and update examples
- update README and docs with new module name

## Testing
- `apt-get install -y pwsh` *(fails: Unable to locate package pwsh)*
- `pwsh -Command '$PSVersionTable'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841f25f5cb08320b1a094145cc378ed